### PR TITLE
fix: remove stray decorator for opportunities route

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -80,8 +80,6 @@ def health():
 def facets(db: Session = Depends(get_db)):
     return crud.get_facets(db)
 
-@app.get("/opportunities", response_model=list[OpportunityOut])
-
 # --------------------------- list/search ---------------------------
 
 class OpportunitiesResponse(BaseModel):


### PR DESCRIPTION
## Summary
- remove stray decorator accidentally registering OpportunitiesResponse as GET handler
- ensure GET /opportunities works with pagination params only

## Testing
- `pytest -q`
- `python - <<'PY'
from app.main import app
for route in app.routes:
    if route.path == '/opportunities' and 'GET' in route.methods:
        print('endpoint', route.endpoint.__name__ if hasattr(route.endpoint, '__name__') else route.endpoint)
        print('params', [p.name for p in route.dependant.query_params])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c428dbebd4832ca4b4404a30f338b4