### PR TITLE
Handle missing FTOP IDs

### DIFF
--- a/app/normalize.py
+++ b/app/normalize.py
@@ -371,8 +371,6 @@ def normalize_vinnova_round(r: dict) -> dict:
 
 
 def normalize_ftop(x: dict) -> dict:
-    uid = str(x.get("id") or x.get("callIdentifier") or "")
-
     def _pick_text(obj: Any, lang: str = "en") -> str | None:
         """Return first non-empty text from nested structures."""
         if not obj:
@@ -421,6 +419,14 @@ def normalize_ftop(x: dict) -> dict:
 
     opens = _pick_date(x.get("openingDate"))
     closes = _pick_date(x.get("deadlineDate"))
+
+    uid = str(x.get("id") or x.get("callIdentifier") or "").strip()
+    if not uid:
+        fallback = title_en or summary_en or ""
+        if fallback:
+            uid = f"ftop-{abs(hash(fallback.lower()))}"
+        else:
+            uid = f"ftop-{abs(hash(json.dumps(x, sort_keys=True)))}"
 
     deadlines: List[Dict[str, Any]] = []
     for d in x.get("deadlineDates") or x.get("deadlines") or []:

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -4,7 +4,7 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 os.environ["TESTING"] = "1"
 
-from app.normalize import normalize
+from app.normalize import normalize, normalize_ftop
 
 def test_normalize_minimal():
     rec = {
@@ -18,3 +18,13 @@ def test_normalize_minimal():
     assert n["deadlines"][0]["date"] == "2025-12-01"
     assert set(n["title"].keys()) == {"sv","en"}
     assert n["topic_codes"] == []
+
+
+def test_ftop_uid_fallback():
+    rec = {"title": {"text": "Example"}}
+    n = normalize_ftop(rec)
+    assert n["source_uid"], "source_uid should not be empty"
+    assert n["id"].startswith("euftop:")
+    # Ensure overall normalize accepts it
+    normalized = normalize(n)
+    assert normalized["source_uid"] == n["source_uid"]


### PR DESCRIPTION
## Summary
- ensure eu_ftop normalization generates fallback ID when id/callIdentifier missing
- add regression test for FTOP fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7d8c7e964832c82b7d3cb05ac9374